### PR TITLE
fix(ci): resolve YAML syntax error in release-workflow.yml

### DIFF
--- a/.github/CLAUDE.md
+++ b/.github/CLAUDE.md
@@ -60,6 +60,12 @@ The actor check for `dependabot-major-prefix` is at the **job level**, not per-s
 - PATH to add: `$RUNNER_TEMP/git-cliff/bin` — the binary is NOT added to `$GITHUB_PATH` automatically
 - Do NOT use any outputs from the action. The "Generate changelog" step calls the binary directly and writes its own `content` key to `$GITHUB_OUTPUT` using the `content<<CLIFF_OUTPUT` heredoc delimiter. `steps.changelog.outputs.content` refers to that manually-written step output, not anything produced by the git-cliff action itself.
 
+### cliff.toml cannot be written with a shell heredoc
+
+The `run: |` YAML literal block parser terminates when it sees a non-empty line with less indentation than the block's first content line. Shell heredocs require the `EOF` end marker at column 0. These constraints are mutually exclusive: if the cliff.toml content is indented to satisfy YAML, the `EOF` marker at column 0 is outside the block and the YAML parser errors; if the content is at column 0 to satisfy bash, the YAML parser terminates the `run:` block at the first `[section]` header.
+
+The fix: put the TOML content in an `env:` variable (`CLIFF_TOML: |`) and write it with `printf '%s\n' "$CLIFF_TOML" > cliff.toml`. YAML strips the block indentation from the env value automatically. Do not convert this back to a heredoc.
+
 ### Alias tags must be excluded
 
 git-cliff and `git tag --list` must both exclude alias tags like `v1` and `v1.2`.

--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -72,46 +72,51 @@ jobs:
 
       # The cliff.toml config is bundled here rather than committed to consuming
       # repos so that all consumers share a single canonical configuration.
+      # It is written from an env var rather than a shell heredoc — heredocs require
+      # the EOF marker at column 0, but the YAML literal block parser terminates
+      # run: | at any line with less indentation than the block's first content line.
+      # These constraints are mutually exclusive; using env: avoids the conflict.
       - name: Write cliff.toml
+        env:
+          CLIFF_TOML: |
+            [changelog]
+            header = ""
+            body = """
+            {% for group, commits in commits | group_by(attribute="group") %}
+            ### {{ group | upper_first }}\n
+            {% for commit in commits %}
+            - {{ commit.message | upper_first }}\
+            {% endfor %}
+            {% endfor %}
+            """
+            trim = true
+
+            [git]
+            conventional_commits = true
+            filter_unconventional = true
+            filter_commits = false
+            # Restricts git-cliff to full semver tags only (e.g. v1.2.3).
+            # Excludes alias tags like v1 and v1.2 which would corrupt version detection.
+            tag_pattern = "v[0-9]+\\.[0-9]+\\.[0-9]+"
+            initial_tag = "v1.0.0"
+            features_always_bump_minor = true
+            breaking_always_bump_major = true
+
+            commit_parsers = [
+              { message = "^feat", group = "Features" },
+              { message = "^fix\\(deps\\)", group = "Dependencies" },
+              { message = "^fix", group = "Bug Fixes" },
+              { message = "^perf", group = "Performance" },
+              { message = "^refactor", group = "Refactor" },
+              { message = "^doc", group = "Documentation" },
+              { message = "^style", skip = true },
+              { message = "^test", skip = true },
+              { message = "^chore", skip = true },
+              { message = "^ci", skip = true },
+              { message = "^build", skip = true },
+            ]
         run: |
-          cat > cliff.toml << 'EOF'
-[changelog]
-header = ""
-body = """
-{% for group, commits in commits | group_by(attribute="group") %}
-### {{ group | upper_first }}\n
-{% for commit in commits %}
-- {{ commit.message | upper_first }}\
-{% endfor %}
-{% endfor %}
-"""
-trim = true
-
-[git]
-conventional_commits = true
-filter_unconventional = true
-filter_commits = false
-# Restricts git-cliff to full semver tags only (e.g. v1.2.3).
-# Excludes alias tags like v1 and v1.2 which would corrupt version detection.
-tag_pattern = "v[0-9]+\\.[0-9]+\\.[0-9]+"
-initial_tag = "v1.0.0"
-features_always_bump_minor = true
-breaking_always_bump_major = true
-
-commit_parsers = [
-  { message = "^feat", group = "Features" },
-  { message = "^fix\\(deps\\)", group = "Dependencies" },
-  { message = "^fix", group = "Bug Fixes" },
-  { message = "^perf", group = "Performance" },
-  { message = "^refactor", group = "Refactor" },
-  { message = "^doc", group = "Documentation" },
-  { message = "^style", skip = true },
-  { message = "^test", skip = true },
-  { message = "^chore", skip = true },
-  { message = "^ci", skip = true },
-  { message = "^build", skip = true },
-]
-EOF
+          printf '%s\n' "$CLIFF_TOML" > cliff.toml
 
       # The v*.*.* glob excludes alias tags (v1, v1.2) so the baseline version
       # is always a full semver tag. An empty result is valid and means no prior


### PR DESCRIPTION
## Summary

- Shell heredocs require the `EOF` marker at column 0
- The YAML literal block parser (`run: |`) terminates at any non-empty line with less indentation than the block's first content line
- These constraints are mutually exclusive: cliff.toml content at column 0 caused GitHub's workflow parser to see `[changelog]` as a YAML flow sequence and fail with a syntax error on line 78

## Fix

Replace the heredoc with an `env:` variable (`CLIFF_TOML: |`) written via `printf '%s\n' "$CLIFF_TOML" > cliff.toml`. YAML strips the block indentation automatically — no EOF marker conflict.

Also documents the constraint in `.github/CLAUDE.md` under Known gotchas.

## Test plan

- [ ] Merge to `main` — calling workflow should parse without error
- [ ] Verify the `release` job writes `cliff.toml` correctly and git-cliff reads it