### PR TITLE
fix(ci): degrade init-check gracefully when github.token lacks admin access

### DIFF
--- a/.github/CLAUDE.md
+++ b/.github/CLAUDE.md
@@ -29,7 +29,7 @@ The actor check for `dependabot-major-prefix` is at the **job level**, not per-s
 
 ### `init-check` job steps
 
-1. **Init check** — assert `allow_squash_merge == true` and `allow_merge_commit == false` via `gh api`; fail with descriptive error if not. Note: `allow_rebase_merge` is intentionally not checked — consumers should also disable it, but the workflow does not enforce this at runtime.
+1. **Init check** — assert `allow_squash_merge == true` and `allow_merge_commit == false` via `gh api`; fail with descriptive error if wrong. If both fields are absent from the response (the common case with `github.token`), logs a warning and continues — see "init-check cannot enforce merge settings with github.token" gotcha. Note: `allow_rebase_merge` is intentionally not checked.
 
 ### `release` job steps (in order)
 
@@ -50,6 +50,12 @@ The actor check for `dependabot-major-prefix` is at the **job level**, not per-s
 ---
 
 ## Known gotchas
+
+### init-check cannot enforce merge settings with github.token
+
+`allow_squash_merge` and `allow_merge_commit` are only returned by the GitHub REST API (`/repos/{owner}/{repo}`) when the authenticated token has admin access to the repository. Admin is not a grantable scope in the `permissions:` block of a GitHub Actions workflow — the valid scopes are `contents`, `pull-requests`, `actions`, etc. `administration` is not among them.
+
+As a result, `init-check` running with `github.token` will always see both fields as absent (`null`) and falls back to a warning rather than a hard failure. The check still enforces misconfiguration when the fields ARE present (e.g., a consumer passes a PAT with admin access as `GH_TOKEN`). Do not change the null-check logic to an error — it would always fail with `github.token`.
 
 ### git-cliff action outputs are broken
 

--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -37,17 +37,28 @@ jobs:
           SQUASH=$(echo "$REPO_DATA" | jq -r '.allow_squash_merge')
           MERGE=$(echo "$REPO_DATA" | jq -r '.allow_merge_commit')
 
-          if [[ "$SQUASH" == "null" || "$MERGE" == "null" ]]; then
-            echo "ERROR: jq could not parse expected fields from API response."
-            echo "  Response: ${REPO_DATA}"
+          # GitHub only returns allow_squash_merge and allow_merge_commit for tokens
+          # with admin access. The github.token in a workflow_call context only has
+          # the scopes granted in permissions: — admin is not a grantable scope.
+          # When both fields are absent, degrade gracefully: warn and skip the check.
+          # If only one field is absent that is unexpected and treated as an error.
+          if [[ "$SQUASH" == "null" && "$MERGE" == "null" ]]; then
+            echo "WARNING: Merge settings are not visible with the current token permissions."
+            echo "  allow_squash_merge and allow_merge_commit require admin API access."
+            echo "  Cannot enforce merge configuration at runtime with github.token."
+            echo "  Verify manually: allow_squash_merge=true, allow_merge_commit=false."
+          elif [[ "$SQUASH" == "null" || "$MERGE" == "null" ]]; then
+            echo "ERROR: Unexpected partial API response — only some merge setting fields were returned."
+            echo "  allow_squash_merge: ${SQUASH}"
+            echo "  allow_merge_commit: ${MERGE}"
             exit 1
-          fi
-
-          if [[ "$SQUASH" != "true" || "$MERGE" != "false" ]]; then
+          elif [[ "$SQUASH" != "true" || "$MERGE" != "false" ]]; then
             echo "ERROR: Repository must have squash merge enabled and merge commits disabled."
             echo "  allow_squash_merge: $SQUASH (expected: true)"
             echo "  allow_merge_commit: $MERGE (expected: false)"
             exit 1
+          else
+            echo "Repository merge settings verified: squash merge enabled, merge commits disabled."
           fi
 
   # Runs when the caller passes trigger: push — by convention, when the calling


### PR DESCRIPTION
## Summary

- `allow_squash_merge` and `allow_merge_commit` are only returned by the GitHub REST API when the token has admin access
- Admin is not a grantable scope in `permissions:` for GitHub Actions workflows
- `github.token` always receives a response without these fields, causing the null check to error

## Fix

Change the behavior when both fields are absent from a hard error to a warning-and-continue. The check still enforces misconfiguration when fields are present (e.g., with a PAT), and adds a distinct error for the partial-response case (only one field missing).

Also documents the limitation in `.github/CLAUDE.md`.

## Test plan

- [ ] Merge to `main` — init-check should log a warning about missing fields and pass
- [ ] Downstream `release` job should run and either skip (no bump-worthy commits) or create a release