### PR TITLE
fix(ci): set explicit release title and ignore merge commits

### DIFF
--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -53,6 +53,7 @@ jobs:
             conventional_commits = true
             filter_unconventional = true
             filter_commits = false
+            ignore_merge_commits = true
             # Restricts git-cliff to full semver tags only (e.g. v1.2.3).
             # Excludes alias tags like v1 and v1.2 which would corrupt version detection.
             tag_pattern = "v[0-9]+\\.[0-9]+\\.[0-9]+"
@@ -224,6 +225,7 @@ jobs:
           echo "Creating GitHub release '${VERSION}' targeting ${GITHUB_SHA}"
 
           if ! gh release create "$VERSION" \
+            --title "$VERSION" \
             --notes-file "$NOTES_FILE" \
             --target "$GITHUB_SHA"; then
             echo "ERROR: 'gh release create' failed for version '${VERSION}'."


### PR DESCRIPTION
## Summary

- Add `--title "$VERSION"` to `gh release create` — without it GitHub auto-generates the title from the latest commit message, producing titles like `v1.0.0: Merge pull request #5 ...`
- Add `ignore_merge_commits = true` to cliff.toml `[git]` section — merge commit messages containing `into main` cause GitHub to render `@main` as a contributor mention in release notes
- Remove `init-check` job — `github.token` cannot read `allow_squash_merge` or `allow_merge_commit` (admin scope is not grantable via `permissions:`), so the check always degraded to a warning with no enforcement value

## Test plan

- [ ] Trigger a release and confirm the title is just the tag (e.g. `v1.0.1`)
- [ ] Confirm release notes contain no `@main` contributor mentions